### PR TITLE
#3: Project doesn't compile ("Cannot find a parameter with this name: onListaDeJogadoresClick")

### DIFF
--- a/app/src/main/java/com/gmail/luizjmfilho/sevenwonders/SevenWondersNavHost.kt
+++ b/app/src/main/java/com/gmail/luizjmfilho/sevenwonders/SevenWondersNavHost.kt
@@ -39,7 +39,6 @@ fun SevenWondersNavHost(
         ) {
             HomeScreen(
                 onCriarPartidaClick = { navController.navigate(ScreenNames.NewGameScreen.name) },
-                onListaDeJogadoresClick = { navController.navigate(ScreenNames.PlayersListScreen.name) },
                 onMatchesHistoryClick = { navController.navigate(ScreenNames.MatchesHistoryScreen.name) },
                 onStatsClick = { navController.navigate(ScreenNames.StatsScreen.name) },
                 onAboutClick = { navController.navigate(ScreenNames.AboutScreen.name) },


### PR DESCRIPTION
# Root cause

The parameter `onListaDeJogadoresClick` of the function `HomeScreen` was removed in d367c77, but its usage in `SevenWondersNavHost` wasn't removed. That causes a compilation error, as a non-existing parameter is being passed to `HomeScreen`.

# Solution

Remove the parameter `onListaDeJogadoresClick` from the call to `HomeScreen` in `SevenWondersNavHost`.